### PR TITLE
add scenario where the access token is empty and refresh token exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,7 @@ export const ApolloLinkJWT = ({
 
     // 2. Refresh the accessToken and update the cache with new tokens if it has expired
     // (on failure of refresh fail gracefully)
-    if (cachedAccessToken && isJwtExpired(cachedAccessToken)) await refreshTokens();
+    if ((cachedAccessToken && isJwtExpired(cachedAccessToken)) || (!cachedAccessToken && cachedRefreshToken)) await refreshTokens();
 
     // 3. Add the accessToken to the request headers if right conditions are met
     if (cacheExists() && !isJwtExpired(cachedAccessToken)) {


### PR DESCRIPTION
This allows to store the access token in memory so that a page reload on a browser will trigger a refresh token query to retrieve a new access token.